### PR TITLE
Change header name to apptio-current-environment

### DIFF
--- a/apptio_lib/apptio.py
+++ b/apptio_lib/apptio.py
@@ -73,7 +73,7 @@ def make_opentoken_headers(opentoken='', key='', secret='', env_id=''):
         
     headers = {
         'apptio-opentoken': opentoken,
-        'apptio-environment-id': env_id,
+        'apptio-current-environment': env_id,
         'app-type': 'Flagship',
     }
 


### PR DESCRIPTION
apptio-environment-id caused errors in the headers when used.

signed-off-by: Daniel Westfahl <Dan.Westfahl@ibm.com>
